### PR TITLE
Update pasteex.json

### DIFF
--- a/bucket/pasteex.json
+++ b/bucket/pasteex.json
@@ -1,13 +1,13 @@
 {
     "homepage": "https://github.com/huiyadanli/PasteEx",
     "description": "Paste the contents of the clipboard into files.",
-    "version": "1.1.7.8",
+    "version": "1.1.8.1",
     "license": {
         "identifier": "GPL-3.0",
         "url": "https://github.com/huiyadanli/PasteEx/blob/master/LICENSE"
     },
-    "url": "https://github.com/huiyadanli/PasteEx/releases/download/1.1.7.8/PasteEx.v1.1.7.8.zip#/dl.7z",
-    "hash": "8989da62bc6bc29ca00f40404d23bb3f618d78f637bdfd74c19e4c825ccf0d40",
+    "url": "https://github.com/huiyadanli/PasteEx/releases/download/1.1.8.1/PasteEx.v1.1.8.1.zip#/dl.7z",
+    "hash": "b3146a7ca1660c6d2dca864a928bb8fa0f01915e72fd972fbe1ca11ff60d27c9",
     "bin": "PasteEx\\PasteEx.exe",
     "persist": [
         "PasteEx\\User"


### PR DESCRIPTION
版本更新到 1.1.8.1。
没用过 Scoop ，不知道这么修改对不对。
hash 应该是用的 SHA256 吧